### PR TITLE
Add extra button visibility toggle

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -144,6 +144,7 @@ const App = () => {
   const [table, setTable] = React.useState("matches_heren");
   const [deleteMatchName, setDeleteMatchName] = React.useState(null);
   const [deleteReason, setDeleteReason] = React.useState("");
+  const [showExtraButtons, setShowExtraButtons] = React.useState(true);
 
   const labels = [
     "Doelpunt NL",
@@ -352,16 +353,23 @@ const App = () => {
     <>
       <button onClick={() => markMoment("")} style={buttonStyle("#ddd", true)}>➕ Markeer moment</button>
       <button onClick={() => markMoment("", true)} style={buttonStyle("#ddd", true)}>⏸️ Markeer + pauze</button>
-      <button onClick={() => markMoment("Doelpunt NL")} style={buttonStyle("#d4edda")}>Doelpunt NL</button>
-      <button onClick={() => markMoment("Tegendoelpunt")} style={buttonStyle("#f8d7da")}>Tegendoelpunt</button>
-      <button onClick={() => markMoment("Schot NL")} style={buttonStyle("#d4edda")}>Schot NL</button>
-      <button onClick={() => markMoment("Schot tegen")} style={buttonStyle("#f8d7da")}>Schot tegen</button>
-      <button onClick={() => markMoment("Balwinst")} style={buttonStyle("#d4edda")}>Balwinst</button>
-      <button onClick={() => markMoment("Balverlies")} style={buttonStyle("#f8d7da")}>Balverlies</button>
-      <button onClick={() => markMoment("Start aanval NL")} style={buttonStyle("#d4edda")}>Start aanval NL</button>
-      <button onClick={() => markMoment("Start tegenaanval")} style={buttonStyle("#f8d7da")}>Start tegenaanval</button>
-      <button onClick={() => markMoment("Verdedigingsmoment NL")} style={buttonStyle("#d4edda")}>Verdedigingsmoment NL</button>
-      <button onClick={() => markMoment("Verdedigingsmoment tegen")} style={buttonStyle("#f8d7da")}>Verdedigingsmoment tegen</button>
+      {showExtraButtons ? (
+        <>
+          <button onClick={() => markMoment("Doelpunt NL")} style={buttonStyle("#d4edda")}>Doelpunt NL</button>
+          <button onClick={() => markMoment("Tegendoelpunt")} style={buttonStyle("#f8d7da")}>Tegendoelpunt</button>
+          <button onClick={() => markMoment("Schot NL")} style={buttonStyle("#d4edda")}>Schot NL</button>
+          <button onClick={() => markMoment("Schot tegen")} style={buttonStyle("#f8d7da")}>Schot tegen</button>
+          <button onClick={() => markMoment("Balwinst")} style={buttonStyle("#d4edda")}>Balwinst</button>
+          <button onClick={() => markMoment("Balverlies")} style={buttonStyle("#f8d7da")}>Balverlies</button>
+          <button onClick={() => markMoment("Start aanval NL")} style={buttonStyle("#d4edda")}>Start aanval NL</button>
+          <button onClick={() => markMoment("Start tegenaanval")} style={buttonStyle("#f8d7da")}>Start tegenaanval</button>
+          <button onClick={() => markMoment("Verdedigingsmoment NL")} style={buttonStyle("#d4edda")}>Verdedigingsmoment NL</button>
+          <button onClick={() => markMoment("Verdedigingsmoment tegen")} style={buttonStyle("#f8d7da")}>Verdedigingsmoment tegen</button>
+          <button onClick={() => setShowExtraButtons(false)} style={buttonStyle()}>Verberg knoppen</button>
+        </>
+      ) : (
+        <button onClick={() => setShowExtraButtons(true)} style={buttonStyle()}>Toon knoppen</button>
+      )
     </>
   );
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -369,7 +369,7 @@ const App = () => {
         </>
       ) : (
         <button onClick={() => setShowExtraButtons(true)} style={buttonStyle()}>Toon knoppen</button>
-      )
+      )}
     </>
   );
 


### PR DESCRIPTION
## Summary
- always show the first two marker buttons
- add state to toggle visibility of the extra marker buttons
- show **Verberg knoppen** or **Toon knoppen** depending on toggle state

## Testing
- `./codex-setup.sh` *(fails: npm ci requires package-lock)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865733e8dfc832dad01d0dc09a8962c